### PR TITLE
Update minute generation instructions with detailed local setup steps

### DIFF
--- a/irc_ref.md
+++ b/irc_ref.md
@@ -136,17 +136,24 @@ To publish the minutes, you must have the meetings Github repository checked out
     - If you don't have one, you can use Google's free SMTP server https://kinsta.com/knowledgebase/free-smtp-server/
     - Update the SCRAWL_EMAIL_* variables in publishing.cfg 
 
-## Downloading and editing raw minutes
+## Download
+Download the raw minutes:
+
 1. Run the `download-raw-minutes` script; flags/options are described below
     - `./download-raw-minutes` downloads the raw minutes and audio for the current date.
     - `./download-raw-minutes -l` downloads the raw minutes and audio for the current date and autolaunches the text and video editors afterward.
     - `./download-raw-minutes -d [YYYY-MM-DD]` downloads the raw minutes and audio for the specified date.
     - `./download-raw-minutes -h` prints help
 1. Minutes and audio are placed in a directory formatted as [YYYY-MM-DD], (e.g. `2018-01-09`)
+
+## Edit
+Edit the downloaded minutes:
+
 1. Edit the WAV file to 1) delete all audio before the Chair starts talking about the Agenda, and 2) delete all audio after the first person hangs up at the end of the call. Basically, clean up the audio to save the content and save the new file as audio.wav or encode to audio.ogg at 32kbps. For example: `oggenc -b 32 audio.wav`
 1. Go to https://w3c-ccg.github.io/meetings/scribe-tool/ and copy/paste irc.log into the text input box at the bottom. Clean up the IRC log accordingly and overwrite irc.log with the edited file.
 
-## Publishing
+## Publish
+Publish the minutes:
 
 1. `cd ../scribe-tool`
 1. `./publish ../<LATEST_MINUTES_DIRECTORY>` (e.g. `./publish ../2018-01-09`)

--- a/irc_ref.md
+++ b/irc_ref.md
@@ -120,8 +120,21 @@ To publish the minutes, you must have the meetings Github repository checked out
 
 1. `git clone git@github.com:w3c-ccg/meetings.git w3c-ccg-meetings`
 1. `cp publishing.cfg.example publishing.cfg`
-1. Setup the text editor in publishing.cfg
-1. Ensure you have an audio editor installed and update and update the variable in publishing.cfg. The default editor used in the config file is [audacity](https://www.audacityteam.org/download/#).
+1. Update the `EDITOR` to your desired editor in publishing.cfg
+1. Install an audio editor update the associated variable in publishing.cfg. The default editor used in the config file is [audacity](https://www.audacityteam.org/download/).
+1. Enable api access to your Twitter account and update the associated variables in publishing.cfg
+    1. Go to https://apps.twitter.com/
+    1. Select "Create New App"
+    1. You can fill out any details; don't need a callback
+    1. Populate the SCRAWL_TWITTER_* variables in publishing.cfg
+1. Enable api access to your LinkedIn account and update associated variables in publishing.cfg
+    1. Go to https://www.linkedin.com/developer/apps
+    1. Select "Create Application"
+    1. After filling in details, generate a client id and secret
+    1. Populate the SCRAWL_LINKEDIN_* variables in publishing.cfg 
+1. Update publishing.cfg with your SMTP information for sending emails.
+    - If you don't have one, you can use Google's free SMTP server https://kinsta.com/knowledgebase/free-smtp-server/
+    - Update the SCRAWL_EMAIL_* variables in publishing.cfg 
 
 ## Publishing
 

--- a/irc_ref.md
+++ b/irc_ref.md
@@ -127,7 +127,7 @@ To publish the minutes, you must have the meetings Github repository checked out
     1. Select "Create New App"
     1. You can fill out any details; don't need a callback
     1. Populate the SCRAWL_TWITTER_* variables in publishing.cfg
-1. Enable api access to your LinkedIn account and update associated variables in publishing.cfg
+1. [NOT IMPLEMENTED YET: feel free to skip this step] Enable api access to your LinkedIn account and update associated variables in publishing.cfg
     1. Go to https://www.linkedin.com/developer/apps
     1. Select "Create Application"
     1. After filling in details, generate a client id and secret

--- a/irc_ref.md
+++ b/irc_ref.md
@@ -136,12 +136,18 @@ To publish the minutes, you must have the meetings Github repository checked out
     - If you don't have one, you can use Google's free SMTP server https://kinsta.com/knowledgebase/free-smtp-server/
     - Update the SCRAWL_EMAIL_* variables in publishing.cfg 
 
-## Publishing
-
-1. `./download-raw-minutes`
-1. `cd <LATEST_MINUTES_DIRECTORY>` (e.g. `cd 2018-01-09`)
+## Downloading and editing raw minutes
+1. Run the `download-raw-minutes` script; flags/options are described below
+    - `./download-raw-minutes` downloads the raw minutes and audio for the current date.
+    - `./download-raw-minutes -l` downloads the raw minutes and audio for the current date and autolaunches the text and video editors afterward.
+    - `./download-raw-minutes -d [YYYY-MM-DD]` downloads the raw minutes and audio for the specified date.
+    - `./download-raw-minutes -h` prints help
+1. Minutes and audio are placed in a directory formatted as [YYYY-MM-DD], (e.g. `2018-01-09`)
 1. Edit the WAV file to 1) delete all audio before the Chair starts talking about the Agenda, and 2) delete all audio after the first person hangs up at the end of the call. Basically, clean up the audio to save the content and save the new file as audio.wav or encode to audio.ogg at 32kbps. For example: `oggenc -b 32 audio.wav`
 1. Go to https://w3c-ccg.github.io/meetings/scribe-tool/ and copy/paste irc.log into the text input box at the bottom. Clean up the IRC log accordingly and overwrite irc.log with the edited file.
+
+## Publishing
+
 1. `cd ../scribe-tool`
 1. `./publish ../<LATEST_MINUTES_DIRECTORY>` (e.g. `./publish ../2018-01-09`)
 


### PR DESCRIPTION
Added some more details around local setup.

This references script updates; PR is here: https://github.com/w3c-ccg/meetings/pull/5